### PR TITLE
Implement initial OrgChart schema and API

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,220 @@
+# agents.md
+
+## Purpose
+This file defines modular tasks for Codex agents implementing **OrgChart AI** features based on the PRD. Each agent will work independently and submit focused pull requests.
+
+## Agents Overview
+
+| Agent Name | Description | Files/Modules | Dependencies |
+|------------|-------------|---------------|--------------|
+| SchemaAgent | Add database tables for digital twins and org chart relationships | lib/db/schema.ts, lib/db/migrations | - |
+| OrgChartAPIAgent | Serve org chart JSON via API | app/api/orgchart/route.ts, lib/db/queries.ts | SchemaAgent |
+| OrgChartUIAgent | Interactive org chart page with pan/zoom | app/orgchart/page.tsx, components/OrgChart.tsx | OrgChartAPIAgent |
+| NodeChatAgent | "Chat" and "Settings" buttons on each node | components/OrgChart.tsx, components/OrgNode.tsx | OrgChartUIAgent |
+| ChatRoutingAgent | Route chat requests to selected agent using its model & prompt | app/(chat)/api/chat/route.ts, lib/ai/prompts.ts | SchemaAgent |
+| AdminUIAgent | Admin pages to manage agents and prompts | app/admin/** | SchemaAgent, ChatRoutingAgent |
+| KBUploadsAgent | Upload documents and store embeddings for RAG | lib/ai/rag.ts, app/api/agents/[id]/documents/** | SchemaAgent |
+| CalendarSyncAgent | Import calendar events for an agent | app/api/agents/[id]/calendar/** | SchemaAgent |
+| TaskSyncAgent | Import task data for an agent | app/api/agents/[id]/tasks/** | SchemaAgent |
+| ChatLogsAgent | Page for users to review their clone's chat history | app/logs/** | ChatRoutingAgent |
+| AccessControlAgent | Implement role-based permissions (admin vs user) | auth setup, middleware.ts | AdminUIAgent |
+
+---
+
+### Agent: SchemaAgent
+**Description**
+Create database schema for AI clones and org chart structure.
+
+**Task Scope & Instructions**
+- Extend `lib/db/schema.ts` with tables for `Agent` (id, name, title, department, userId, systemPrompt, modelId, avatarUrl) and `OrgRelationship` (parentId, childId).
+- Generate migrations in `lib/db/migrations`.
+- Update `lib/db/queries.ts` with CRUD helpers for agents and org relationships.
+
+**Acceptance Criteria**
+- Migrations run without error.
+- Queries can create/read/update/delete agents and relationships.
+
+**Dependencies**
+- None
+
+---
+
+### Agent: OrgChartAPIAgent
+**Description**
+Expose org chart data through a REST endpoint.
+
+**Task Scope & Instructions**
+- Create `app/api/orgchart/route.ts` with GET handler returning all agents and relationships as JSON.
+- Use helpers from `lib/db/queries.ts`.
+- Include pagination to handle up to 200 nodes.
+
+**Acceptance Criteria**
+- `GET /api/orgchart` responds with array of agents and relationships.
+- Unit test verifies HTTP 200 and expected structure.
+
+**Dependencies**
+- SchemaAgent
+
+---
+
+### Agent: OrgChartUIAgent
+**Description**
+Render interactive org chart in the frontend.
+
+**Task Scope & Instructions**
+- Create `app/orgchart/page.tsx` and `components/OrgChart.tsx`.
+- Fetch data from `/api/orgchart` and display nodes with name, title, department and avatar.
+- Implement pan and zoom controls.
+
+**Acceptance Criteria**
+- Page loads org chart within 3 seconds for 200 nodes.
+- Nodes are clickable.
+
+**Dependencies**
+- OrgChartAPIAgent
+
+---
+
+### Agent: NodeChatAgent
+**Description**
+Add Chat and Settings controls to each org chart node.
+
+**Task Scope & Instructions**
+- Extend `components/OrgChart.tsx` with per-node "Chat" and "Settings" buttons.
+- Clicking "Chat" navigates to `/chat/[agentId]`.
+- "Settings" should link to admin configuration if the user is an admin.
+
+**Acceptance Criteria**
+- Buttons visible on hover.
+- Clicking chat opens the correct chat page.
+
+**Dependencies**
+- OrgChartUIAgent
+
+---
+
+### Agent: ChatRoutingAgent
+**Description**
+Handle chat requests for a specific agent.
+
+**Task Scope & Instructions**
+- Modify `app/(chat)/api/chat/route.ts` to accept `agentId`.
+- Load agent configuration (prompt, model) from DB using `lib/db/queries.ts`.
+- Use these settings when calling the AI provider.
+
+**Acceptance Criteria**
+- Messages routed to the selected agent return responses using its model and prompt.
+- Existing chat tests continue to pass.
+
+**Dependencies**
+- SchemaAgent
+
+---
+
+### Agent: AdminUIAgent
+**Description**
+Build admin interface for managing agents.
+
+**Task Scope & Instructions**
+- Create pages under `app/admin` for listing, creating, and editing agents.
+- Allow editing system prompts, model selection, and knowledge base sources.
+- Restrict access to users with admin role.
+
+**Acceptance Criteria**
+- Admin can CRUD agents from the UI.
+- Form validations exist for required fields.
+
+**Dependencies**
+- SchemaAgent
+- ChatRoutingAgent
+
+---
+
+### Agent: KBUploadsAgent
+**Description**
+Enable document upload for an agent's knowledge base and store embeddings.
+
+**Task Scope & Instructions**
+- Add API routes under `app/api/agents/[id]/documents` for upload and retrieval.
+- Store files with Vercel Blob and embeddings in vector DB (pgvector or similar).
+- Update chat route to perform RAG on these documents before calling the LLM.
+
+**Acceptance Criteria**
+- Documents upload successfully and are retrievable.
+- RAG results appear in chat responses when relevant.
+
+**Dependencies**
+- SchemaAgent
+- ChatRoutingAgent
+
+---
+
+### Agent: CalendarSyncAgent
+**Description**
+Import calendar events into an agent's knowledge base.
+
+**Task Scope & Instructions**
+- Provide utility to parse iCal feed or connect to Google Calendar API.
+- Store upcoming events linked to an agent.
+- Expose API endpoints for manual sync.
+
+**Acceptance Criteria**
+- Calendar events can be fetched and stored.
+- Chat answers questions about availability using this data.
+
+**Dependencies**
+- SchemaAgent
+- KBUploadsAgent
+
+---
+
+### Agent: TaskSyncAgent
+**Description**
+Sync tasks from Jira/Asana/Trello for an agent.
+
+**Task Scope & Instructions**
+- Create service to import tasks via API or CSV.
+- Store tasks linked to an agent for RAG.
+- Allow manual refresh through admin UI.
+
+**Acceptance Criteria**
+- Tasks are stored and retrievable.
+- Chat can reference task status when asked.
+
+**Dependencies**
+- SchemaAgent
+- KBUploadsAgent
+
+---
+
+### Agent: ChatLogsAgent
+**Description**
+Allow humans to review their clone's conversation history.
+
+**Task Scope & Instructions**
+- Create pages under `app/logs` to display chats for the signed-in user's agent.
+- Only the agent owner and admins may access these logs.
+
+**Acceptance Criteria**
+- Users can see past conversations with their clone.
+
+**Dependencies**
+- ChatRoutingAgent
+
+---
+
+### Agent: AccessControlAgent
+**Description**
+Implement role-based permissions.
+
+**Task Scope & Instructions**
+- Extend Auth.js setup and middleware to distinguish admin vs regular user.
+- Enforce role checks in admin and log routes.
+
+**Acceptance Criteria**
+- Unauthorized users cannot access admin pages.
+- Unit test verifies middleware redirects.
+
+**Dependencies**
+- AdminUIAgent
+

--- a/app/api/orgchart/route.ts
+++ b/app/api/orgchart/route.ts
@@ -1,0 +1,26 @@
+import { auth } from '@/app/(auth)/auth';
+import { NextRequest } from 'next/server';
+import { getAgents, getOrgRelationships } from '@/lib/db/queries';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  const { searchParams } = request.nextUrl;
+  const limit = parseInt(searchParams.get('limit') || '50', 10);
+  const page = parseInt(searchParams.get('page') || '1', 10);
+  const offset = (page - 1) * limit;
+
+  try {
+    const agents = await getAgents({ limit, offset });
+    const relationships = await getOrgRelationships();
+    return Response.json({ agents, relationships });
+  } catch (_) {
+    return Response.json('Failed to fetch org chart', { status: 500 });
+  }
+}

--- a/lib/db/migrations/0006_agents_and_relationships.sql
+++ b/lib/db/migrations/0006_agents_and_relationships.sql
@@ -1,0 +1,34 @@
+CREATE TABLE IF NOT EXISTS "Agent" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+    "name" varchar(128) NOT NULL,
+    "title" varchar(128) NOT NULL,
+    "department" varchar(128),
+    "userId" uuid,
+    "systemPrompt" text,
+    "modelId" varchar(64) NOT NULL,
+    "avatarUrl" varchar(256)
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "OrgRelationship" (
+    "parentId" uuid NOT NULL,
+    "childId" uuid NOT NULL,
+    CONSTRAINT "OrgRelationship_parentId_childId_pk" PRIMARY KEY("parentId","childId")
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "Agent" ADD CONSTRAINT "Agent_userId_User_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "OrgRelationship" ADD CONSTRAINT "OrgRelationship_parentId_Agent_id_fk" FOREIGN KEY ("parentId") REFERENCES "public"."Agent"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "OrgRelationship" ADD CONSTRAINT "OrgRelationship_childId_Agent_id_fk" FOREIGN KEY ("childId") REFERENCES "public"."Agent"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -44,5 +44,12 @@
       "tag": "0005_wooden_whistler",
       "breakpoints": true
     }
+    ,{
+      "idx": 6,
+      "version": "7",
+      "when": 1747499820000,
+      "tag": "0006_agents_and_relationships",
+      "breakpoints": true
+    }
   ]
 }

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -26,6 +26,10 @@ import {
   vote,
   type DBMessage,
   type Chat,
+  agent,
+  orgRelationship,
+  type Agent,
+  type OrgRelationship,
 } from './schema';
 import type { ArtifactKind } from '@/components/artifact';
 import { generateUUID } from '../utils';
@@ -467,6 +471,83 @@ export async function getMessageCountByUserId({
     console.error(
       'Failed to get message count by user id for the last 24 hours from database',
     );
+    throw error;
+  }
+}
+
+// Agent CRUD operations
+export async function createAgent(data: Omit<Agent, 'id'> & { id?: string }) {
+  try {
+    const id = data.id ?? generateUUID();
+    return await db.insert(agent).values({ ...data, id }).returning();
+  } catch (error) {
+    console.error('Failed to create agent in database');
+    throw error;
+  }
+}
+
+export async function getAgentById({ id }: { id: string }) {
+  try {
+    const [row] = await db.select().from(agent).where(eq(agent.id, id));
+    return row;
+  } catch (error) {
+    console.error('Failed to get agent by id from database');
+    throw error;
+  }
+}
+
+export async function getAgents({ limit = 50, offset = 0 } = {}) {
+  try {
+    return await db.select().from(agent).limit(limit).offset(offset);
+  } catch (error) {
+    console.error('Failed to get agents from database');
+    throw error;
+  }
+}
+
+export async function updateAgent({ id, ...values }: { id: string } & Partial<Omit<Agent, 'id'>>) {
+  try {
+    return await db.update(agent).set(values).where(eq(agent.id, id)).returning();
+  } catch (error) {
+    console.error('Failed to update agent in database');
+    throw error;
+  }
+}
+
+export async function deleteAgent({ id }: { id: string }) {
+  try {
+    return await db.delete(agent).where(eq(agent.id, id));
+  } catch (error) {
+    console.error('Failed to delete agent from database');
+    throw error;
+  }
+}
+
+export async function createOrgRelationship({ parentId, childId }: { parentId: string; childId: string }) {
+  try {
+    return await db.insert(orgRelationship).values({ parentId, childId });
+  } catch (error) {
+    console.error('Failed to create org relationship');
+    throw error;
+  }
+}
+
+export async function getOrgRelationships() {
+  try {
+    return await db.select().from(orgRelationship);
+  } catch (error) {
+    console.error('Failed to get org relationships');
+    throw error;
+  }
+}
+
+export async function deleteOrgRelationship({ parentId, childId }: { parentId: string; childId: string }) {
+  try {
+    return await db
+      .delete(orgRelationship)
+      .where(and(eq(orgRelationship.parentId, parentId), eq(orgRelationship.childId, childId)));
+  } catch (error) {
+    console.error('Failed to delete org relationship');
     throw error;
   }
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -150,3 +150,33 @@ export const suggestion = pgTable(
 );
 
 export type Suggestion = InferSelectModel<typeof suggestion>;
+
+export const agent = pgTable('Agent', {
+  id: uuid('id').primaryKey().notNull().defaultRandom(),
+  name: varchar('name', { length: 128 }).notNull(),
+  title: varchar('title', { length: 128 }).notNull(),
+  department: varchar('department', { length: 128 }),
+  userId: uuid('userId').references(() => user.id),
+  systemPrompt: text('systemPrompt'),
+  modelId: varchar('modelId', { length: 64 }).notNull(),
+  avatarUrl: varchar('avatarUrl', { length: 256 }),
+});
+
+export type Agent = InferSelectModel<typeof agent>;
+
+export const orgRelationship = pgTable(
+  'OrgRelationship',
+  {
+    parentId: uuid('parentId')
+      .notNull()
+      .references(() => agent.id, { onDelete: 'cascade' }),
+    childId: uuid('childId')
+      .notNull()
+      .references(() => agent.id, { onDelete: 'cascade' }),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.parentId, table.childId] }),
+  }),
+);
+
+export type OrgRelationship = InferSelectModel<typeof orgRelationship>;


### PR DESCRIPTION
## Summary
- add Agent and OrgRelationship tables
- create migration for new tables
- expose `/api/orgchart` endpoint
- provide CRUD helpers for agents and relationships

## Testing
- `pnpm lint` *(fails to install pnpm)*
- `pnpm test` *(fails to install pnpm)*