### PR TITLE
Implement OrgChart UI and agent chat routing

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -14,6 +14,7 @@ import {
   getMessagesByChatId,
   saveChat,
   saveMessages,
+  getAgentById,
 } from '@/lib/db/queries';
 import { generateUUID, getTrailingMessageId } from '@/lib/utils';
 import { generateTitleFromUserMessage } from '../../actions';
@@ -40,7 +41,7 @@ export async function POST(request: Request) {
   }
 
   try {
-    const { id, message, selectedChatModel } = requestBody;
+    const { id, message, selectedChatModel, agentId } = requestBody;
 
     const session = await auth();
 
@@ -63,6 +64,8 @@ export async function POST(request: Request) {
         },
       );
     }
+
+    const agent = agentId ? await getAgentById({ id: agentId }) : null;
 
     const chat = await getChatById({ id });
 
@@ -95,6 +98,12 @@ export async function POST(request: Request) {
       country,
     };
 
+    const modelToUse = agent?.modelId ?? selectedChatModel;
+    const systemToUse = agent?.systemPrompt ?? systemPrompt({
+      selectedChatModel: modelToUse,
+      requestHints,
+    });
+
     await saveMessages({
       messages: [
         {
@@ -111,12 +120,12 @@ export async function POST(request: Request) {
     return createDataStreamResponse({
       execute: (dataStream) => {
         const result = streamText({
-          model: myProvider.languageModel(selectedChatModel),
-          system: systemPrompt({ selectedChatModel, requestHints }),
+          model: myProvider.languageModel(modelToUse),
+          system: systemToUse,
           messages,
           maxSteps: 5,
           experimental_activeTools:
-            selectedChatModel === 'chat-model-reasoning'
+            modelToUse === 'chat-model-reasoning'
               ? []
               : [
                   'getWeather',

--- a/app/(chat)/api/chat/schema.ts
+++ b/app/(chat)/api/chat/schema.ts
@@ -7,6 +7,7 @@ const textPartSchema = z.object({
 
 export const postRequestBodySchema = z.object({
   id: z.string().uuid(),
+  agentId: z.string().uuid().optional(),
   message: z.object({
     id: z.string().uuid(),
     createdAt: z.coerce.date(),

--- a/app/(chat)/page.tsx
+++ b/app/(chat)/page.tsx
@@ -7,7 +7,7 @@ import { DataStreamHandler } from '@/components/data-stream-handler';
 import { auth } from '../(auth)/auth';
 import { redirect } from 'next/navigation';
 
-export default async function Page() {
+export default async function Page({ searchParams }: { searchParams?: { agentId?: string } }) {
   const session = await auth();
 
   if (!session) {
@@ -15,6 +15,7 @@ export default async function Page() {
   }
 
   const id = generateUUID();
+  const agentId = searchParams?.agentId;
 
   const cookieStore = await cookies();
   const modelIdFromCookie = cookieStore.get('chat-model');
@@ -30,6 +31,7 @@ export default async function Page() {
           selectedVisibilityType="private"
           isReadonly={false}
           session={session}
+          agentId={agentId}
         />
         <DataStreamHandler id={id} />
       </>
@@ -46,6 +48,7 @@ export default async function Page() {
         selectedVisibilityType="private"
         isReadonly={false}
         session={session}
+        agentId={agentId}
       />
       <DataStreamHandler id={id} />
     </>

--- a/app/orgchart/page.tsx
+++ b/app/orgchart/page.tsx
@@ -1,0 +1,35 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { auth } from '../(auth)/auth';
+import { OrgChart } from '@/components/OrgChart';
+
+export const dynamic = 'force-dynamic';
+
+export default async function Page() {
+  const session = await auth();
+
+  if (!session) {
+    redirect('/api/auth/guest');
+  }
+
+  const cookieStore = cookies();
+  const base = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000';
+  const res = await fetch(`${base}/api/orgchart`, {
+    headers: {
+      cookie: cookieStore.toString(),
+    },
+    cache: 'no-store',
+  });
+
+  if (!res.ok) {
+    throw new Error('Failed to load org chart');
+  }
+
+  const data = await res.json();
+
+  return (
+    <div className="w-full h-full p-4">
+      <OrgChart agents={data.agents} relationships={data.relationships} />
+    </div>
+  );
+}

--- a/components/OrgChart.tsx
+++ b/components/OrgChart.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { OrgNode } from './OrgNode';
+
+export interface Agent {
+  id: string;
+  name: string;
+  title: string | null;
+  department: string | null;
+  avatarUrl: string | null;
+}
+
+export interface OrgRelationship {
+  parentId: string;
+  childId: string;
+}
+
+interface TreeNode extends Agent {
+  children: Array<TreeNode>;
+}
+
+function buildTree(agents: Agent[], relationships: OrgRelationship[]): TreeNode[] {
+  const map = new Map<string, TreeNode>();
+  agents.forEach((a) => map.set(a.id, { ...a, children: [] }));
+  relationships.forEach((r) => {
+    const parent = map.get(r.parentId);
+    const child = map.get(r.childId);
+    if (parent && child) parent.children.push(child);
+  });
+  const childrenSet = new Set(relationships.map((r) => r.childId));
+  return Array.from(map.values()).filter((n) => !childrenSet.has(n.id));
+}
+
+export function OrgChart({
+  agents,
+  relationships,
+}: {
+  agents: Agent[];
+  relationships: OrgRelationship[];
+}) {
+  const roots = buildTree(agents, relationships);
+  const [pos, setPos] = useState({ x: 0, y: 0 });
+  const [scale, setScale] = useState(1);
+  const dragging = useRef(false);
+  const start = useRef({ x: 0, y: 0 });
+
+  const onWheel = (e: React.WheelEvent) => {
+    e.preventDefault();
+    setScale((s) => {
+      const next = e.deltaY > 0 ? s - 0.1 : s + 0.1;
+      return Math.min(Math.max(next, 0.5), 2);
+    });
+  };
+
+  const onMouseDown = (e: React.MouseEvent) => {
+    dragging.current = true;
+    start.current = { x: e.clientX - pos.x, y: e.clientY - pos.y };
+  };
+
+  const onMouseMove = (e: React.MouseEvent) => {
+    if (!dragging.current) return;
+    setPos({ x: e.clientX - start.current.x, y: e.clientY - start.current.y });
+  };
+
+  const onMouseUp = () => {
+    dragging.current = false;
+  };
+
+  return (
+    <div
+      className="w-full h-full overflow-hidden relative bg-background"
+      onWheel={onWheel}
+      onMouseDown={onMouseDown}
+      onMouseMove={onMouseMove}
+      onMouseUp={onMouseUp}
+      onMouseLeave={onMouseUp}
+    >
+      <div
+        style={{
+          transform: `translate(${pos.x}px, ${pos.y}px) scale(${scale})`,
+          transformOrigin: '0 0',
+        }}
+      >
+        <div className="flex gap-8">
+          {roots.map((root) => (
+            <TreeNode key={root.id} node={root} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TreeNode({ node }: { node: TreeNode }) {
+  return (
+    <OrgNode agent={node}>
+      {node.children.map((child) => (
+        <TreeNode key={child.id} node={child} />
+      ))}
+    </OrgNode>
+  );
+}

--- a/components/OrgNode.tsx
+++ b/components/OrgNode.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { useState } from 'react';
+
+export interface OrgNodeProps {
+  agent: {
+    id: string;
+    name: string;
+    title: string | null;
+    department: string | null;
+    avatarUrl: string | null;
+  };
+  children?: React.ReactNode;
+}
+
+export function OrgNode({ agent, children }: OrgNodeProps) {
+  const [hover, setHover] = useState(false);
+
+  return (
+    <div className="flex flex-col items-center">
+      <div
+        className="relative group p-2 bg-card border rounded-md text-center"
+        onMouseEnter={() => setHover(true)}
+        onMouseLeave={() => setHover(false)}
+      >
+        {agent.avatarUrl && (
+          <Image
+            src={agent.avatarUrl}
+            alt={agent.name}
+            width={48}
+            height={48}
+            className="rounded-full mx-auto mb-1"
+          />
+        )}
+        <div className="text-sm font-medium">{agent.name}</div>
+        {agent.title && (
+          <div className="text-xs text-muted-foreground">{agent.title}</div>
+        )}
+        {agent.department && (
+          <div className="text-xs text-muted-foreground">{agent.department}</div>
+        )}
+        <div
+          className={`absolute -top-1 right-0 flex gap-1 ${hover ? 'opacity-100' : 'opacity-0'} transition-opacity`}
+        >
+          <Link
+            href={`/chat?agentId=${agent.id}`}
+            className="text-xs bg-primary text-primary-foreground rounded px-1"
+          >
+            Chat
+          </Link>
+          <Link
+            href={`/admin/agents/${agent.id}`}
+            className="text-xs bg-muted rounded px-1"
+          >
+            Settings
+          </Link>
+        </div>
+      </div>
+      {children && <div className="mt-4 flex gap-4">{children}</div>}
+    </div>
+  );
+}

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -25,6 +25,7 @@ export function Chat({
   selectedVisibilityType,
   isReadonly,
   session,
+  agentId,
 }: {
   id: string;
   initialMessages: Array<UIMessage>;
@@ -32,6 +33,7 @@ export function Chat({
   selectedVisibilityType: VisibilityType;
   isReadonly: boolean;
   session: Session;
+  agentId?: string;
 }) {
   const { mutate } = useSWRConfig();
 
@@ -55,6 +57,7 @@ export function Chat({
       id,
       message: body.messages.at(-1),
       selectedChatModel,
+      agentId,
     }),
     onFinish: () => {
       mutate(unstable_serialize(getChatHistoryPaginationKey));

--- a/tests/routes/orgchart.test.ts
+++ b/tests/routes/orgchart.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from '../fixtures';
+import {
+  createAgent,
+  createOrgRelationship,
+} from '@/lib/db/queries';
+
+export const AGENT_MODEL = 'chat-model';
+
+
+test.describe.serial('/api/orgchart', () => {
+  test('returns agents and relationships', async ({ adaContext }) => {
+    const [parent] = await createAgent({
+      name: 'Alice',
+      title: 'CEO',
+      department: 'Executive',
+      userId: null,
+      systemPrompt: null,
+      modelId: AGENT_MODEL,
+      avatarUrl: null,
+    });
+    const [child] = await createAgent({
+      name: 'Bob',
+      title: 'Engineer',
+      department: 'Engineering',
+      userId: null,
+      systemPrompt: null,
+      modelId: AGENT_MODEL,
+      avatarUrl: null,
+    });
+    await createOrgRelationship({ parentId: parent.id, childId: child.id });
+
+    const response = await adaContext.request.get('/api/orgchart');
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+    expect(body).toHaveProperty('agents');
+    expect(body).toHaveProperty('relationships');
+
+    const agentIds = body.agents.map((a: any) => a.id);
+    expect(agentIds).toContain(parent.id);
+    expect(agentIds).toContain(child.id);
+
+    const hasRelationship = body.relationships.some(
+      (r: any) => r.parentId === parent.id && r.childId === child.id,
+    );
+    expect(hasRelationship).toBe(true);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add org chart page that fetches `/api/orgchart`
- create `OrgChart` and `OrgNode` components with basic pan/zoom
- show Chat and Settings buttons on each node
- allow chat requests to include `agentId` and load agent config

## Testing
- `pnpm lint` *(fails: connect EHOSTUNREACH)*
- `pnpm test` *(fails: connect EHOSTUNREACH)*